### PR TITLE
Remove static keywords from variables source and target so that this cla...

### DIFF
--- a/src/main/org/openscience/cdk/smsd/algorithm/rgraph/CDKRMapHandler.java
+++ b/src/main/org/openscience/cdk/smsd/algorithm/rgraph/CDKRMapHandler.java
@@ -60,7 +60,7 @@ public class CDKRMapHandler {
      * Returns source molecule
      * @return the source
      */
-    public static IAtomContainer getSource() {
+    public IAtomContainer getSource() {
         return source;
     }
 
@@ -68,7 +68,7 @@ public class CDKRMapHandler {
      * Set source molecule
      * @param aSource the source to set
      */
-    public static void setSource(IAtomContainer aSource) {
+    public void setSource(IAtomContainer aSource) {
         source = aSource;
     }
 
@@ -76,7 +76,7 @@ public class CDKRMapHandler {
      * Returns target molecule
      * @return the target
      */
-    public static IAtomContainer getTarget() {
+    public IAtomContainer getTarget() {
         return target;
     }
 
@@ -84,12 +84,12 @@ public class CDKRMapHandler {
      * Set target molecule
      * @param aTarget the target to set
      */
-    public static void setTarget(IAtomContainer aTarget) {
+    public void setTarget(IAtomContainer aTarget) {
         target = aTarget;
     }
     private List<Map<Integer, Integer>> mappings;
-    private static IAtomContainer source;
-    private static IAtomContainer target;
+    private IAtomContainer source;
+    private IAtomContainer target;
     private boolean timeoutFlag = false;
 
     /**


### PR DESCRIPTION
Remove static keywords from variables source and target so that this class can be used in a threaded environment.