### PR TITLE
Fix/bond electron counts

### DIFF
--- a/base/data/src/main/java/org/openscience/cdk/Bond.java
+++ b/base/data/src/main/java/org/openscience/cdk/Bond.java
@@ -361,6 +361,12 @@ public class Bond extends ElectronContainer implements IBond, Serializable, Clon
                 case QUADRUPLE:
                     this.electronCount = 8;
                     break;
+                case QUINTUPLE:
+                    this.electronCount = 10;
+                    break;
+                case SEXTUPLE:
+                    this.electronCount = 12;
+                    break;
                 default:
                     this.electronCount = 0;
                     break;

--- a/base/interfaces/src/main/java/org/openscience/cdk/interfaces/IBond.java
+++ b/base/interfaces/src/main/java/org/openscience/cdk/interfaces/IBond.java
@@ -57,6 +57,8 @@ public interface IBond extends IElectronContainer {
          * Order.DOUBLE.numeric()    // 2
          * Order.TRIPLE.numeric()    // 3
          * Order.QUADRUPLE.numeric() // 4
+         * Order.QUINTUPLE.numeric() // 5
+         * Order.SEXTUPLE.numeric()  // 6
          * Order.UNSET.numeric()     // 0
          * }</pre>
          *

--- a/base/silent/src/main/java/org/openscience/cdk/silent/Bond.java
+++ b/base/silent/src/main/java/org/openscience/cdk/silent/Bond.java
@@ -355,6 +355,12 @@ public class Bond extends ElectronContainer implements IBond, Serializable, Clon
                 case QUADRUPLE:
                     this.electronCount = 8;
                     break;
+                case QUINTUPLE:
+                    this.electronCount = 10;
+                    break;
+                case SEXTUPLE:
+                    this.electronCount = 12;
+                    break;
                 default:
                     this.electronCount = 0;
                     break;

--- a/base/test-interfaces/src/test/java/org/openscience/cdk/interfaces/AbstractBondTest.java
+++ b/base/test-interfaces/src/test/java/org/openscience/cdk/interfaces/AbstractBondTest.java
@@ -287,6 +287,20 @@ public abstract class AbstractBondTest extends AbstractElectronContainerTest {
         b.setOrder(Order.QUADRUPLE);
         Assert.assertNotNull(b.getElectronCount());
         Assert.assertEquals(8, b.getElectronCount().intValue());
+
+        // OK, a bit hypothetical
+        b.setAtom(c, 0);
+        b.setAtom(o, 1);
+        b.setOrder(Order.QUINTUPLE);
+        Assert.assertNotNull(b.getElectronCount());
+        Assert.assertEquals(10, b.getElectronCount().intValue());
+
+        // OK, a bit hypothetical
+        b.setAtom(c, 0);
+        b.setAtom(o, 1);
+        b.setOrder(Order.SEXTUPLE);
+        Assert.assertNotNull(b.getElectronCount());
+        Assert.assertEquals(12, b.getElectronCount().intValue());
     }
 
     @Test


### PR DESCRIPTION
I discovered today that the electron counts for QUINTUPLE and SEXTUPLE were not set yet. Fixed now.