### PR TITLE
Feature/pcore cleanup

### DIFF
--- a/tool/pcore/pom.xml
+++ b/tool/pcore/pom.xml
@@ -50,6 +50,11 @@
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
+            <artifactId>cdk-silent</artifactId>
+            <version>${project.parent.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
             <artifactId>cdk-core</artifactId>
             <version>${project.parent.version}</version>
         </dependency>

--- a/tool/pcore/src/main/java/org/openscience/cdk/pharmacophore/PharmacophoreAtom.java
+++ b/tool/pcore/src/main/java/org/openscience/cdk/pharmacophore/PharmacophoreAtom.java
@@ -110,6 +110,7 @@ public class PharmacophoreAtom extends Atom {
     public void setMatchingAtoms(int[] atomIndices) {
         this.matchingAtoms = new int[atomIndices.length];
         System.arraycopy(atomIndices, 0, this.matchingAtoms, 0, atomIndices.length);
+        Arrays.sort(matchingAtoms);
     }
 
     /**
@@ -125,28 +126,19 @@ public class PharmacophoreAtom extends Atom {
         return matchingAtoms;
     }
 
+    @Override public int hashCode() {
+        int result = smarts != null ? smarts.hashCode() : 0;
+        result = 31 * result + (matchingAtoms != null ? Arrays.hashCode(matchingAtoms) : 0);
+        return result;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (!(o instanceof PharmacophoreAtom)) return false;
 
-        PharmacophoreAtom patom = (PharmacophoreAtom) o;
-        Arrays.sort(matchingAtoms);
-        int[] tmp = patom.getMatchingAtoms();
-        Arrays.sort(tmp);
-        boolean atomIndicesMatch = true;
-
-        if (matchingAtoms.length == tmp.length) {
-            for (int i = 0; i < matchingAtoms.length; i++) {
-                if (tmp[i] != matchingAtoms[i]) {
-                    atomIndicesMatch = false;
-                    break;
-                }
-            }
-        } else
-            atomIndicesMatch = false;
-
-        return smarts.equals(patom.getSmarts()) && symbol.equals(patom.getSymbol())
-                && point3d.equals(patom.getPoint3d()) && atomIndicesMatch;
+        PharmacophoreAtom that = (PharmacophoreAtom) o;
+        return smarts.equals(that.getSmarts()) && symbol.equals(that.getSymbol())
+                && point3d.equals(that.getPoint3d()) && Arrays.equals(this.matchingAtoms, that.matchingAtoms);
     }
 
 }

--- a/tool/pcore/src/main/java/org/openscience/cdk/pharmacophore/PharmacophoreMatcher.java
+++ b/tool/pcore/src/main/java/org/openscience/cdk/pharmacophore/PharmacophoreMatcher.java
@@ -422,8 +422,7 @@ public class PharmacophoreMatcher {
                     PharmacophoreAtom patom = new PharmacophoreAtom(smarts, qatom.getSymbol(), coords);
                     // n.b. mapping[] is reusued for efficient to need to make an explict copy 
                     patom.setMatchingAtoms(Arrays.copyOf(mapping, mapping.length));
-                    if (!pharmacophoreMolecule.contains(patom))
-                        pharmacophoreMolecule.addAtom(patom);
+                    pharmacophoreMolecule.addAtom(patom);
                     count++;
                 }
             }

--- a/tool/pcore/src/main/java/org/openscience/cdk/pharmacophore/PharmacophoreMatcher.java
+++ b/tool/pcore/src/main/java/org/openscience/cdk/pharmacophore/PharmacophoreMatcher.java
@@ -418,11 +418,7 @@ public class PharmacophoreMatcher {
                                                  .uniqueAtoms();
                 
                 for (final int[] mapping : mappings) {
-                    final Point3d coords = getEffectiveCoordinates(input, mapping);
-                    PharmacophoreAtom patom = new PharmacophoreAtom(smarts, qatom.getSymbol(), coords);
-                    // n.b. mapping[] is reusued for efficient to need to make an explict copy 
-                    patom.setMatchingAtoms(Arrays.copyOf(mapping, mapping.length));
-                    pharmacophoreMolecule.addAtom(patom);
+                    pharmacophoreMolecule.addAtom(newPCoreAtom(input, qatom, smarts, mapping));
                     count++;
                 }
             }
@@ -508,6 +504,14 @@ public class PharmacophoreMatcher {
         }
 
         return pharmacophoreMolecule;
+    }
+
+    private PharmacophoreAtom newPCoreAtom(IAtomContainer input, PharmacophoreQueryAtom qatom, String smarts, int[] mapping) {
+        final Point3d coords = getEffectiveCoordinates(input, mapping);
+        PharmacophoreAtom patom = new PharmacophoreAtom(smarts, qatom.getSymbol(), coords);
+        // n.b. mapping[] is reused for efficient to need to make an explict copy 
+        patom.setMatchingAtoms(Arrays.copyOf(mapping, mapping.length));
+        return patom;
     }
 
     private void prepareInput(IAtomContainer input) throws CDKException {

--- a/tool/pcore/src/main/java/org/openscience/cdk/pharmacophore/PharmacophoreQueryAtom.java
+++ b/tool/pcore/src/main/java/org/openscience/cdk/pharmacophore/PharmacophoreQueryAtom.java
@@ -21,6 +21,8 @@ package org.openscience.cdk.pharmacophore;
 import org.openscience.cdk.Atom;
 import org.openscience.cdk.interfaces.IAtom;
 import org.openscience.cdk.isomorphism.matchers.IQueryAtom;
+import org.openscience.cdk.isomorphism.matchers.IQueryAtomContainer;
+import org.openscience.cdk.smiles.smarts.parser.SMARTSParser;
 
 /**
  * Represents a query pharmacophore group.
@@ -41,6 +43,7 @@ import org.openscience.cdk.isomorphism.matchers.IQueryAtom;
 public class PharmacophoreQueryAtom extends Atom implements IQueryAtom {
 
     private String smarts;
+    private IQueryAtomContainer[] compiledSmarts;
 
     /**
      * Creat a new query pharmacophore group
@@ -51,6 +54,13 @@ public class PharmacophoreQueryAtom extends Atom implements IQueryAtom {
     public PharmacophoreQueryAtom(String symbol, String smarts) {
         setSymbol(symbol);
         this.smarts = smarts;
+        // Note that we allow a special form of SMARTS where the | operator
+        // represents logical or of multi-atom groups (as opposed to ','
+        // which is for single atom matches)
+        String[] subSmarts = smarts.split("\\|");
+        this.compiledSmarts = new IQueryAtomContainer[subSmarts.length];
+        for (int i = 0; i < compiledSmarts.length; i++)
+            compiledSmarts[i] = SMARTSParser.parse(subSmarts[i], null);
     }
 
     /**
@@ -60,6 +70,14 @@ public class PharmacophoreQueryAtom extends Atom implements IQueryAtom {
      */
     public String getSmarts() {
         return smarts;
+    }
+
+    /**
+     * Accessed the compiled SMARTS for this pcore query atom.  
+     * @return compiled SMARTS
+     */
+    IQueryAtomContainer[] getCompiledSmarts() {
+        return compiledSmarts;    
     }
 
     /**

--- a/tool/pcore/src/test/java/org/openscience/cdk/pharmacophore/PharmacophoreMatcherTest.java
+++ b/tool/pcore/src/test/java/org/openscience/cdk/pharmacophore/PharmacophoreMatcherTest.java
@@ -29,14 +29,12 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.openscience.cdk.ConformerContainer;
-import org.openscience.cdk.DefaultChemObjectBuilder;
-import org.openscience.cdk.aromaticity.Aromaticity;
 import org.openscience.cdk.exception.CDKException;
 import org.openscience.cdk.interfaces.IAtomContainer;
 import org.openscience.cdk.interfaces.IBond;
 import org.openscience.cdk.io.iterator.IteratingMDLConformerReader;
 import org.openscience.cdk.io.iterator.IteratingSDFReader;
-import org.openscience.cdk.tools.manipulator.AtomContainerManipulator;
+import org.openscience.cdk.silent.SilentChemObjectBuilder;
 
 /**
  * @cdk.module test-pcore
@@ -56,7 +54,7 @@ public class PharmacophoreMatcherTest {
         String filename = "data/mdl/pcoretest1.sdf";
         InputStream ins = PharmacophoreMatcherTest.class.getClassLoader().getResourceAsStream(filename);
         IteratingMDLConformerReader reader = new IteratingMDLConformerReader(ins,
-                DefaultChemObjectBuilder.getInstance());
+                SilentChemObjectBuilder.getInstance());
         if (reader.hasNext()) conformers = (ConformerContainer) reader.next();
     }
 
@@ -217,7 +215,7 @@ public class PharmacophoreMatcherTest {
     public void testCNSPcore() throws CDKException, IOException {
         String filename = "data/mdl/cnssmarts.sdf";
         InputStream ins = PharmacophoreMatcherTest.class.getClassLoader().getResourceAsStream(filename);
-        IteratingSDFReader reader = new IteratingSDFReader(ins, DefaultChemObjectBuilder.getInstance());
+        IteratingSDFReader reader = new IteratingSDFReader(ins, SilentChemObjectBuilder.getInstance());
 
         PharmacophoreQuery query = new PharmacophoreQuery();
         PharmacophoreQueryAtom arom = new PharmacophoreQueryAtom("A", "c1ccccc1");
@@ -230,8 +228,6 @@ public class PharmacophoreMatcherTest {
         reader.hasNext();
         IAtomContainer mol = (IAtomContainer) reader.next();
         reader.close();
-        AtomContainerManipulator.percieveAtomTypesAndConfigureAtoms(mol);
-        Aromaticity.cdkLegacy().apply(mol);
 
         PharmacophoreMatcher matcher = new PharmacophoreMatcher(query);
         boolean status = matcher.matches(mol);
@@ -248,7 +244,7 @@ public class PharmacophoreMatcherTest {
     public void testMatchingBonds() throws CDKException, IOException {
         String filename = "data/mdl/cnssmarts.sdf";
         InputStream ins = PharmacophoreMatcherTest.class.getClassLoader().getResourceAsStream(filename);
-        IteratingSDFReader reader = new IteratingSDFReader(ins, DefaultChemObjectBuilder.getInstance());
+        IteratingSDFReader reader = new IteratingSDFReader(ins, SilentChemObjectBuilder.getInstance());
 
         PharmacophoreQuery query = new PharmacophoreQuery();
         PharmacophoreQueryAtom arom = new PharmacophoreQueryAtom("A", "c1ccccc1");
@@ -261,8 +257,6 @@ public class PharmacophoreMatcherTest {
         reader.hasNext();
         IAtomContainer mol = (IAtomContainer) reader.next();
         reader.close();
-        AtomContainerManipulator.percieveAtomTypesAndConfigureAtoms(mol);
-        Aromaticity.cdkLegacy().apply(mol);
 
         PharmacophoreMatcher matcher = new PharmacophoreMatcher(query);
         boolean status = matcher.matches(mol);
@@ -286,7 +280,7 @@ public class PharmacophoreMatcherTest {
     public void testAngleMatch1() throws Exception {
         String filename = "data/mdl/cnssmarts.sdf";
         InputStream ins = PharmacophoreMatcherTest.class.getClassLoader().getResourceAsStream(filename);
-        IteratingSDFReader reader = new IteratingSDFReader(ins, DefaultChemObjectBuilder.getInstance());
+        IteratingSDFReader reader = new IteratingSDFReader(ins, SilentChemObjectBuilder.getInstance());
 
         PharmacophoreQuery query = new PharmacophoreQuery();
         PharmacophoreQueryAtom n1 = new PharmacophoreQueryAtom("BasicAmine", "[NX3;h2,h1,H1,H2;!$(NC=O)]");
@@ -301,8 +295,6 @@ public class PharmacophoreMatcherTest {
         reader.hasNext();
         IAtomContainer mol = (IAtomContainer) reader.next();
         reader.close();
-        AtomContainerManipulator.percieveAtomTypesAndConfigureAtoms(mol);
-        Aromaticity.cdkLegacy().apply(mol);
 
         PharmacophoreMatcher matcher = new PharmacophoreMatcher(query);
         boolean status = matcher.matches(mol);
@@ -313,7 +305,7 @@ public class PharmacophoreMatcherTest {
     public void testAngleMatch2() throws Exception {
         String filename = "data/mdl/cnssmarts.sdf";
         InputStream ins = PharmacophoreMatcherTest.class.getClassLoader().getResourceAsStream(filename);
-        IteratingSDFReader reader = new IteratingSDFReader(ins, DefaultChemObjectBuilder.getInstance());
+        IteratingSDFReader reader = new IteratingSDFReader(ins, SilentChemObjectBuilder.getInstance());
 
         PharmacophoreQuery query = new PharmacophoreQuery();
         PharmacophoreQueryAtom n1 = new PharmacophoreQueryAtom("BasicAmine", "[NX3;h2,h1,H1,H2;!$(NC=O)]");
@@ -328,8 +320,6 @@ public class PharmacophoreMatcherTest {
         reader.hasNext();
         IAtomContainer mol = (IAtomContainer) reader.next();
         reader.close();
-        AtomContainerManipulator.percieveAtomTypesAndConfigureAtoms(mol);
-        Aromaticity.cdkLegacy().apply(mol);
 
         PharmacophoreMatcher matcher = new PharmacophoreMatcher(query);
         boolean status = matcher.matches(mol);
@@ -413,7 +403,7 @@ public class PharmacophoreMatcherTest {
 
         String filename = "data/pcore/multismartpcore.sdf";
         InputStream ins = PharmacophoreMatcherTest.class.getClassLoader().getResourceAsStream(filename);
-        IteratingSDFReader reader = new IteratingSDFReader(ins, DefaultChemObjectBuilder.getInstance());
+        IteratingSDFReader reader = new IteratingSDFReader(ins, SilentChemObjectBuilder.getInstance());
 
         IAtomContainer mol = (IAtomContainer) reader.next();
         Assert.assertTrue(matcher.matches(mol));


### PR DESCRIPTION
Nope... cant send to cdk/cdk. Sigh will refork from there.

Rebase pcore searching on newer APIs. Correctness improved and perhaps a small speed boost. Also methods don't depend on each other being called first (i.e. getUniqueAtoms no longer needs getAtoms). Adding a wrapping to the Pattern API would be cleaner and more efficient:

```java
Pattern pattern = PharmacorphorePattern.create("input.xml");
if (pattern.matches(molecule)) {

} 
```

